### PR TITLE
Fix weird behavior related to Qiskit `CUGate` issues

### DIFF
--- a/src/qiskit_symb/circuit/library/parametric_gates/u.py
+++ b/src/qiskit_symb/circuit/library/parametric_gates/u.py
@@ -1,5 +1,5 @@
 r"""Symbolic :math:`U(\theta, \phi, \lambda)` and
-controlled-:math:`U(\theta, \phi, \lambda)` gates module"""
+controlled-:math:`U(\theta, \phi, \lambda, \gamma)` gates module"""
 
 import sympy
 from sympy.matrices import Matrix
@@ -10,30 +10,31 @@ from ...controlledgate import ControlledGate
 class UGate(Gate):
     r"""Symbolic :math:`U(\theta, \phi, \lambda)` gate class"""
 
-    def __init__(self, theta, phi, lam):
+    def __init__(self, theta, phi, lam, _gamma=0):
         """todo"""
-        params = [theta, phi, lam]
+        params = [theta, phi, lam, _gamma]
         super().__init__(name='u', num_qubits=1, params=params)
 
     def __sympy__(self):
         """todo"""
-        theta, phi, lam = self._get_params_expr()
+        theta, phi, lam, gamma = self._get_params_expr()
         cos = sympy.cos(theta / 2)
         sin = sympy.sin(theta / 2)
         i = sympy.I
         exp = sympy.exp
-        return Matrix([[cos, -exp(i * lam) * sin],
-                       [exp(i * phi) * sin, exp(i * (phi + lam)) * cos]])
+        return exp(i * gamma) * Matrix([[cos, -exp(i * lam) * sin],
+                                        [exp(i * phi) * sin, exp(i * (phi + lam)) * cos]])
 
 
 class CUGate(ControlledGate):
-    r"""Symbolic controlled-:math:`U(\theta, \phi, \lambda)` gate class"""
+    r"""Symbolic controlled-:math:`U(\theta, \phi, \lambda, \gamma)` gate class"""
 
-    def __init__(self, theta, phi, lam, ctrl_qubits=None, target_qubits=None, ctrl_state=None):
+    def __init__(self, theta, phi, lam, gamma=0,
+                 ctrl_qubits=None, target_qubits=None, ctrl_state=None):
         """todo"""
         # pylint: disable=too-many-arguments
-        params = [theta, phi, lam]
-        base_gate = UGate(theta, phi, lam)
+        params = [theta, phi, lam, gamma]
+        base_gate = UGate(theta, phi, lam, gamma)
         super().__init__(name='cu', num_qubits=2, params=params,
                          ctrl_qubits=ctrl_qubits, target_qubits=target_qubits,
                          ctrl_state=ctrl_state, base_gate=base_gate)

--- a/src/qiskit_symb/circuit/random.py
+++ b/src/qiskit_symb/circuit/random.py
@@ -43,8 +43,7 @@ def random_parametric_circuit(num_qubits, depth, seed=None):
             'cry': (standard_gates.CRYGate, 2, 1),
             'crz': (standard_gates.CRZGate, 2, 1),
             'csx': (standard_gates.CSXGate, 2, 0),
-            # https://github.com/Qiskit/qiskit-terra/issues/7326
-            # 'cu': (standard_gates.CUGate, 2, 4),
+            'cu': (standard_gates.CUGate, 2, 4),
             'cy': (standard_gates.CYGate, 2, 0),
             'cz': (standard_gates.CZGate, 2, 0),
             'rxx': (standard_gates.RXXGate, 2, 1),

--- a/src/qiskit_symb/utils.py
+++ b/src/qiskit_symb/utils.py
@@ -11,7 +11,7 @@ def get_init(name):
     """todo"""
     if name not in NAME_TO_INIT:
         raise NotImplementedError(
-            f'Gate "{name}" is not implemented in qiskit-symb')
+            f'Gate "{name}" is not implemented in qiskit-symb, use Qiskit transpiler!')
     return NAME_TO_INIT[name]
 
 

--- a/tests/test_ctrl_parametric_gates.py
+++ b/tests/test_ctrl_parametric_gates.py
@@ -26,13 +26,8 @@ def test_cu(theta, phi, lam, seed):
     pars_vals = [theta, phi, lam]
     pars = ParameterVector(name='pars', length=len(pars_vals))
     circuit = get_random_controlled(base_gate=UGate(*pars), seed=seed)
-    try:
-        arr1 = Operator(circuit.assign_parameters(pars_vals)).data
-    except TypeError:
-        # https://github.com/Qiskit/qiskit-terra/issues/10002
-        return
-    arr2 = symb_Operator(
-        circuit).subs({pars: pars_vals}).to_numpy()
+    arr1 = Operator(circuit.assign_parameters(pars_vals)).data
+    arr2 = symb_Operator(circuit).subs({pars: pars_vals}).to_numpy()
     assert numpy.allclose(arr1, arr2)
 
 
@@ -93,13 +88,8 @@ def test_cr(theta, phi, seed):
     pars_vals = [theta, phi]
     pars = ParameterVector(name='pars', length=len(pars_vals))
     circuit = get_random_controlled(base_gate=RGate(*pars), seed=seed)
-    try:
-        arr1 = Operator(circuit.assign_parameters(pars_vals)).data
-    except TypeError:
-        # https://github.com/Qiskit/qiskit-terra/issues/10002
-        return
-    arr2 = symb_Operator(
-        circuit).subs({pars: pars_vals}).to_numpy()
+    arr1 = Operator(circuit.assign_parameters(pars_vals)).data
+    arr2 = symb_Operator(circuit).subs({pars: pars_vals}).to_numpy()
     assert numpy.allclose(arr1, arr2)
 
 


### PR DESCRIPTION
At the moment, there is no way to properly solve issue #4. Indeed, it is due to a Qiskit well known problem, related to the global phase parameter  _gamma_ in the `CUGate` constructor, with no corresponding parameter in the `UGate` constructor (potential fix: https://github.com/Qiskit/qiskit-terra/pull/11032).

Currently, the best option is to simply set the `CUGate` as not implemented to avoid weird behavior and misleading error messages.

